### PR TITLE
Fix logic in example code (logic-in-positive)

### DIFF
--- a/logic-in-positive.md
+++ b/logic-in-positive.md
@@ -38,7 +38,7 @@ Then written in the positive:
 
 ```js
 isBlackOrWhite(black, white) => {
-    if (black && white) {
+    if (black || white) {
         return true;
     }
     return false;


### PR DESCRIPTION
As the name of the function suggests, it should return true if the either of the black or white variables are true, which requires the `||` (OR) operator, instead of the `&&` (AND) operator.